### PR TITLE
Fix signedness of size variable in `key_calculate_real`

### DIFF
--- a/fcgienc_key.c
+++ b/fcgienc_key.c
@@ -23,7 +23,7 @@
 static int key_calculate_real(fcgienc_crypt * fc)
 {
 	int i;
-	size_t len;
+	ssize_t len;
 	unsigned char mkhex[32], ivhex[16];
 	char decodebuf[KEY_SIZE];
 	int decodelen;
@@ -88,7 +88,10 @@ static int key_calculate_real(fcgienc_crypt * fc)
 	len = DecryptAesCBC((unsigned char *)decodebuf, decodelen, keystr, mkhex, ivhex);
 
 	if (len < 0)
+	{
+		log_message(ENCRYPT_LOG_ERR, "AES-CBC decryption failed with key %s", fc->dataKeyId);
 		return -1;
+	}
 
 	// store into variable
 	memcpy(fc->dataKey, keystr, len);

--- a/fcgienc_keythread.c
+++ b/fcgienc_keythread.c
@@ -76,7 +76,7 @@ static void log_keythread(const char *fmt, ...)
 static int key_calculate_real(fcgienc_crypt * fc)
 {
 	int i;
-	size_t len;
+	ssize_t len;
 	unsigned char mkhex[32], ivhex[16];
 	char decodebuf[KEY_SIZE];
 	int decodelen;
@@ -141,7 +141,10 @@ static int key_calculate_real(fcgienc_crypt * fc)
 	len = DecryptAesCBC((unsigned char *)decodebuf, decodelen, keystr, mkhex, ivhex);
 
 	if (len < 0)
+	{
+		log_keythread("KEY-THREAD - AES-CBC decryption failed with key %s", fc->dataKeyId);
 		return -1;
+	}
 
 	// store into variable
 	memcpy(fc->dataKey, keystr, len);


### PR DESCRIPTION
In case of error while decrypting the data key, the unsigned size_t would get
assigned the value -1 (18446744073709551615) causing the following crash:
```
*** buffer overflow detected ***: /usr/lib64/httpd/modules/mod_enckeythread.bin terminated
======= Backtrace: =========
/lib64/libc.so.6(__fortify_fail+0x37)[0x7f917ca73567]
/lib64/libc.so.6(+0x100450)[0x7f917ca71450]
/usr/lib64/httpd/modules/mod_enckeythread.bin[0x403acc]
/usr/lib64/httpd/modules/mod_enckeythread.bin[0x40403a]
/lib64/libc.so.6(__libc_start_main+0xfd)[0x7f917c98fd5d]
/usr/lib64/httpd/modules/mod_enckeythread.bin[0x402119]
======= Memory map: ========
```